### PR TITLE
Create MCLanguageFileHelper.yml

### DIFF
--- a/.github/workflows/MCLanguageFileHelper.yml
+++ b/.github/workflows/MCLanguageFileHelper.yml
@@ -1,0 +1,19 @@
+            - name: MC Language File Helper
+# You may pin to the exact commit or the version.
+# uses: RedLime/mc-lang-translation-action@073885fa9bb1a5bdabba9d74f68a40a4761debf8
+uses: RedLime/mc-lang-translation-action@v2.1
+with:
+  # language files base path
+  base-path: 
+  # The directory where language files expect editable language files are created/loaded. Based on `base-path`.
+  lang-files-path: # optional, default is ./
+  # The directory where editable language files are created/loaded. Based on `base-path`.
+  editable-files-path: # optional, default is ./editable
+  # A filename suffix string to identify a language files in the `base-path` directory.
+  end-with: # optional, default is .json
+  # To be inserted before value of `end-with` in the filename to identify the editable language file.
+  editable-suffix: # optional, default is .editable
+  # To be inserted before value of `end-with` in the filename to identify the backup language file.
+  backup-suffix: # optional, default is .prev
+  # A filename without `end-with` or `*-suffix` to identify the base language file.
+  default-language: # optional, default is en_us

--- a/.github/workflows/MCLanguageFileHelper.yml
+++ b/.github/workflows/MCLanguageFileHelper.yml
@@ -1,19 +1,27 @@
-            - name: MC Language File Helper
-# You may pin to the exact commit or the version.
-# uses: RedLime/mc-lang-translation-action@073885fa9bb1a5bdabba9d74f68a40a4761debf8
-uses: RedLime/mc-lang-translation-action@v2.1
-with:
-  # language files base path
-  base-path: 
-  # The directory where language files expect editable language files are created/loaded. Based on `base-path`.
-  lang-files-path: # optional, default is ./
-  # The directory where editable language files are created/loaded. Based on `base-path`.
-  editable-files-path: # optional, default is ./editable
-  # A filename suffix string to identify a language files in the `base-path` directory.
-  end-with: # optional, default is .json
-  # To be inserted before value of `end-with` in the filename to identify the editable language file.
-  editable-suffix: # optional, default is .editable
-  # To be inserted before value of `end-with` in the filename to identify the backup language file.
-  backup-suffix: # optional, default is .prev
-  # A filename without `end-with` or `*-suffix` to identify the base language file.
-  default-language: # optional, default is en_us
+name: MC Language File Helper
+
+on:
+  workflow_dispatch:
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: MC Language File Helper
+        uses: RedLime/mc-lang-translation-action@v2.1
+        with:
+          # language files base path
+          base-path: <set-your-path>
+          # The directory where language files expect editable language files are created/loaded. Based on `base-path`.
+          lang-files-path: # optional, default is ./
+          # The directory where editable language files are created/loaded. Based on `base-path`.
+          editable-files-path: # optional, default is ./editable
+          # A filename suffix string to identify a language files in the `base-path` directory.
+          end-with: # optional, default is .json
+          # To be inserted before value of `end-with` in the filename to identify the editable language file.
+          editable-suffix: # optional, default is .editable
+          # To be inserted before value of `end-with` in the filename to identify the backup language file.
+          backup-suffix: # optional, default is .prev
+          # A filename without `end-with` or `*-suffix` to identify the base language file.
+          default-language: # optional, default is en_us

--- a/.github/workflows/MCLanguageFileHelper.yml
+++ b/.github/workflows/MCLanguageFileHelper.yml
@@ -9,19 +9,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: MC Language File Helper
-        uses: RedLime/mc-lang-translation-action@v2.1
+        uses: RedLime/mc-lang-translation-action@073885fa9bb1a5bdabba9d74f68a40a4761debf8
         with:
           # language files base path
           base-path: <set-your-path>
           # The directory where language files expect editable language files are created/loaded. Based on `base-path`.
-          lang-files-path: # optional, default is ./
+          lang-files-path: ./ # optional, default is ./
           # The directory where editable language files are created/loaded. Based on `base-path`.
-          editable-files-path: # optional, default is ./editable
+          editable-files-path: ./editable # optional, default is ./editable
           # A filename suffix string to identify a language files in the `base-path` directory.
-          end-with: # optional, default is .json
+          end-with: .json # optional, default is .json
           # To be inserted before value of `end-with` in the filename to identify the editable language file.
-          editable-suffix: # optional, default is .editable
+          editable-suffix: .editable # optional, default is .editable
           # To be inserted before value of `end-with` in the filename to identify the backup language file.
           backup-suffix: # optional, default is .prev
           # A filename without `end-with` or `*-suffix` to identify the base language file.
-          default-language: # optional, default is en_us
+          default-language: en_us # optional, default is en_us


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Introduce .github/workflows/MCLanguageFileHelper.yml to run RedLime/mc-lang-translation-action@v2.1 with customizable base-path, lang-files-path, editable-files-path, end-with, editable-suffix, backup-suffix, and default-language

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced an automated workflow to assist with updating and maintaining language files, improving localization consistency across the app.
  - Enhances reliability of translation updates with safeguards to reduce errors during localization maintenance.
  - No user-facing behavior changes; foundation for smoother, more accurate translations in future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->