### PR TITLE
Update RealitySplitterEnchantment.java

### DIFF
--- a/src/main/java/net/mcreator/caos/enchantment/RealitySplitterEnchantment.java
+++ b/src/main/java/net/mcreator/caos/enchantment/RealitySplitterEnchantment.java
@@ -22,6 +22,27 @@ public class RealitySplitterEnchantment extends CaosModElements.ModElement {
 			super(Enchantment.Rarity.VERY_RARE, EnchantmentType.WEAPON, slots);
 		}
 
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentType;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraftforge.registries.ObjectHolder;
+import net.mcreator.caos.CaosModElements;
+@CaosModElements.ModElement.Tag
+public class RealitySplitterEnchantment extends CaosModElements.ModElement {
+    @ObjectHolder("caos:reality_splitter")
+    public static final Enchantment enchantment = null;
+    public RealitySplitterEnchantment(CaosModElements instance) {
+        super(instance, 1);
+    }
+    @Override
+    public void initElements() {
+        elements.enchantments.add(() -> new CustomEnchantment(EquipmentSlotType.MAINHAND).setRegistryName("reality_splitter"));
+    }
+    public static class CustomEnchantment extends Enchantment {
+        public CustomEnchantment(EquipmentSlotType... slots) {
+            super(Enchantment.Rarity.VERY_RARE, EnchantmentType.WEAPON, slots);
+        }
+
 		@Override
 		public int getMinLevel() {
 			return 1;


### PR DESCRIPTION
## Summary by Sourcery

Register the "reality_splitter" enchantment by adding a new RealitySplitterEnchantment mod element.

New Features:
- Add RealitySplitterEnchantment mod element with initElements method to register the custom "reality_splitter" enchantment on the main hand slot
- Introduce an @ObjectHolder field to hold the registered enchantment instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Reality Splitter enchantment for weapons (main hand).
  * Available at levels I–II and classified as very rare.
  * Obtainable through standard enchanting and compatible with enchanted books.
  * Not a curse and not restricted to treasure-only sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->