### PR TITLE
Update RealityRendererProcedure.java

### DIFF
--- a/src/main/java/net/mcreator/caos/procedures/RealityRendererProcedure.java
+++ b/src/main/java/net/mcreator/caos/procedures/RealityRendererProcedure.java
@@ -33,8 +33,7 @@ public class RealityRendererProcedure extends CaosModElements.ModElement {
 				((sourceentity instanceof LivingEntity) ? ((LivingEntity) sourceentity).getHeldItemMainhand() : ItemStack.EMPTY).getItem()))) {
 			if (EnchantmentHelper.getEnchantmentLevel(RealitySplitterEnchantment.enchantment,
 					((sourceentity instanceof LivingEntity) ? ((LivingEntity) sourceentity).getHeldItemMainhand() : ItemStack.EMPTY)) != 0) {
-				(((sourceentity instanceof LivingEntity) ? ((LivingEntity) sourceentity).getHeldItemMainhand() : ItemStack.EMPTY))
-						.addEnchantment(RealitySplitterEnchantment.enchantment, 1);
+				(((sourceentity instanceof LivingEntity) ? ((LivingEntity) sourceentity).getHeldItemMainhand() : ItemStack.EMPTY));
                 ItemStack stack = (sourceentity instanceof LivingEntity)
                     ? ((LivingEntity) sourceentity).getHeldItemMainhand()
                     : ItemStack.EMPTY;

--- a/src/main/java/net/mcreator/caos/procedures/RealityRendererProcedure.java
+++ b/src/main/java/net/mcreator/caos/procedures/RealityRendererProcedure.java
@@ -33,7 +33,6 @@ public class RealityRendererProcedure extends CaosModElements.ModElement {
 				((sourceentity instanceof LivingEntity) ? ((LivingEntity) sourceentity).getHeldItemMainhand() : ItemStack.EMPTY).getItem()))) {
 			if (EnchantmentHelper.getEnchantmentLevel(RealitySplitterEnchantment.enchantment,
 					((sourceentity instanceof LivingEntity) ? ((LivingEntity) sourceentity).getHeldItemMainhand() : ItemStack.EMPTY)) != 0) {
-				(((sourceentity instanceof LivingEntity) ? ((LivingEntity) sourceentity).getHeldItemMainhand() : ItemStack.EMPTY));
                 ItemStack stack = (sourceentity instanceof LivingEntity)
                     ? ((LivingEntity) sourceentity).getHeldItemMainhand()
                     : ItemStack.EMPTY;


### PR DESCRIPTION
## Summary by Sourcery

Remove redundant enchantment application from the held item in RealityRendererProcedure and extract the main hand item into a stack variable

Enhancements:
- Remove addEnchantment call for RealitySplitterEnchantment in the procedure
- Introduce a stack variable to hold the player’s main hand ItemStack