### PR TITLE
Update RiftKnockbackProcedure.java

### DIFF
--- a/src/main/java/net/mcreator/caos/procedures/RiftKnockbackProcedure.java
+++ b/src/main/java/net/mcreator/caos/procedures/RiftKnockbackProcedure.java
@@ -24,7 +24,7 @@ public class RiftKnockbackProcedure extends CaosModElements.ModElement {
 		double speed = 0;
 		double Yaw = 0;
 		if ((ItemTags.getCollection().getTagByID(new ResourceLocation(("caos:empowered_rift_blade").toLowerCase(java.util.Locale.ENGLISH)))
-				.contains(((entity instanceof LivingEntity) ? ((LivingEntity) entity).getHeldItemMainhand() : ItemStack.EMPTY).getItem()))) {
+				.contains(((sourceentity instanceof LivingEntity) ? ((LivingEntity) sourceentity).getHeldItemMainhand() : ItemStack.EMPTY).getItem()))) {
 			speed = (double) 0.2;
 			Yaw = (double) (sourceentity.rotationYaw);
 			entity.setMotion(((speed) * Math.cos((((Yaw) + 90) * (Math.PI / 180)))), (entity.getMotion().getY()),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use sourceentity instead of entity when checking for the empowered rift blade tag to correctly apply knockback logic